### PR TITLE
Upgraded AutoMapper to v5.0.2.

### DIFF
--- a/Sources/AutoMapper.Unity/AutoMapper.Unity.csproj
+++ b/Sources/AutoMapper.Unity/AutoMapper.Unity.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=5.0.2.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoMapper.5.0.2\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Sources/AutoMapper.Unity/packages.config
+++ b/Sources/AutoMapper.Unity/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
+  <package id="AutoMapper" version="5.0.2" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />
 </packages>

--- a/Tests/AutoMapper.Unity.TestProfiles/AutoMapper.Unity.TestProfiles.csproj
+++ b/Tests/AutoMapper.Unity.TestProfiles/AutoMapper.Unity.TestProfiles.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=5.0.2.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoMapper.5.0.2\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -50,9 +50,7 @@
     <Compile Include="SecondProfile.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Tests/AutoMapper.Unity.TestProfiles/packages.config
+++ b/Tests/AutoMapper.Unity.TestProfiles/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
+  <package id="AutoMapper" version="5.0.2" targetFramework="net45" />
 </packages>

--- a/Tests/AutoMapper.Unity.Tests/AutoMapper.Unity.Tests.csproj
+++ b/Tests/AutoMapper.Unity.Tests/AutoMapper.Unity.Tests.csproj
@@ -37,8 +37,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=5.0.2.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoMapper.5.0.2\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FluentAssertions">

--- a/Tests/AutoMapper.Unity.Tests/packages.config
+++ b/Tests/AutoMapper.Unity.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
+  <package id="AutoMapper" version="5.0.2" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="FluentAssertions" version="3.2.1" targetFramework="net45" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />


### PR DESCRIPTION
I upgraded the AutoMapper reference using NuGet Package Manager in Visual Studio 2015. It built for me without any errors. I wasn't able to figure out how to run the unit tests. Visual Studio wouldn't recognize them. So I pointed our application to the fork and everything worked great. All I had to do in our application was move my CreateMap's from the overridden Configure() method to the constructor of my Profile. I also had to fix some circular references in our mappings that were bad anyway, but error in the new version due to the new .PreserveReferences() method. Let me know if you need anything or have any questions. Thanks.