### PR TITLE
Upgraded AutoMapper to v5.1.1.

### DIFF
--- a/Sources/AutoMapper.Unity/AutoMapper.Unity.csproj
+++ b/Sources/AutoMapper.Unity/AutoMapper.Unity.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=5.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoMapper.5.1.1\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Sources/AutoMapper.Unity/packages.config
+++ b/Sources/AutoMapper.Unity/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
+  <package id="AutoMapper" version="5.1.1" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />
 </packages>

--- a/Tests/AutoMapper.Unity.TestProfiles/AutoMapper.Unity.TestProfiles.csproj
+++ b/Tests/AutoMapper.Unity.TestProfiles/AutoMapper.Unity.TestProfiles.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=5.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoMapper.5.1.1\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Tests/AutoMapper.Unity.TestProfiles/packages.config
+++ b/Tests/AutoMapper.Unity.TestProfiles/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
+  <package id="AutoMapper" version="5.1.1" targetFramework="net45" />
 </packages>

--- a/Tests/AutoMapper.Unity.Tests/AutoMapper.Unity.Tests.csproj
+++ b/Tests/AutoMapper.Unity.Tests/AutoMapper.Unity.Tests.csproj
@@ -37,8 +37,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper, Version=4.2.0.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AutoMapper.4.2.0\lib\net45\AutoMapper.dll</HintPath>
+    <Reference Include="AutoMapper, Version=5.1.1.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoMapper.5.1.1\lib\net45\AutoMapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FluentAssertions">

--- a/Tests/AutoMapper.Unity.Tests/packages.config
+++ b/Tests/AutoMapper.Unity.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="4.2.0" targetFramework="net45" />
+  <package id="AutoMapper" version="5.1.1" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="FluentAssertions" version="3.2.1" targetFramework="net45" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />


### PR DESCRIPTION
Hi,

i have upgraded to the newest AutoMapper Version!

AutoMapper.Unity throws an Exception in Version 5.0.16 when I call RegisterMapper. With this upgrade everything works fine!
